### PR TITLE
Add Slack project dividers

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -121,16 +121,18 @@ if not report:
     text = "No active projects with upcoming milestones."
 else:
     lines = ["*Weekly Critical Milestones*"]
-    for r in report:
+    for idx, r in enumerate(report):
         lines.append(f"• *{r['project']}*")
         lines.append(f"    – Next:   {r['next']}")
         lines.append(f"    – Launch: {r['launch']}")
         if r['comments']:
             lines.append("    – Recent comments:")
-            for idx, cm in enumerate(r['comments'], start=1):
-                lines.append(f"       {idx}. {cm}")
+            for cidx, cm in enumerate(r['comments'], start=1):
+                lines.append(f"       {cidx}. {cm}")
         else:
             lines.append("    – Recent comments: –")
+        if idx != len(report) - 1:
+            lines.append("────────────────────")
     text = "\n".join(lines)
 
 slack_resp = session.post(WEBHOOK, json={"text": text})


### PR DESCRIPTION
## Summary
- add dividers between each project in Slack report

## Testing
- `python -m py_compile generate_report.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5cec19c8832297a2221025000f4b